### PR TITLE
Rust lob service implementation

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["bigfatwhale <bigfatwhale@gmail.com>"]
 
 [dependencies]
 nom = "^4.0"
-crossbeam = "0.3.2"
+crossbeam = "0.8.2"

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -107,7 +107,7 @@ pub struct AuctionSummaryMsg {
 pub struct AddOrderMsg {
     pub timestamp : u32, 
     pub msg_type  : char,
-    pub order_id  : u64, 
+    pub id  : u64, 
     pub side      : char, 
     pub shares    : u32, 
     pub symbol    : String,  
@@ -133,7 +133,7 @@ pub struct AuctionUpdateMsg {
 pub struct OrderCancelMsg {
     pub timestamp : u32, 
     pub msg_type  : char,
-    pub order_id  : u64, 
+    pub id  : u64, 
     pub shares    : u32
 }
 
@@ -141,7 +141,7 @@ pub struct OrderCancelMsg {
 pub struct OrderExecutedMsg {
     pub timestamp : u32, 
     pub msg_type  : char,
-    pub order_id  : u64, 
+    pub id  : u64, 
     pub shares    : u32, 
     pub exec_id   : u64
 }
@@ -165,7 +165,7 @@ pub struct TradeBreakMsg {
 pub struct TradeMsg {
     pub timestamp : u32, 
     pub msg_type  : char,
-    pub order_id  : u64,
+    pub id  : u64,
     pub side      : char,
     pub shares    : u32, 
     pub symbol    : String, 
@@ -229,7 +229,7 @@ named!(parse_add_order<&str, AddOrderMsg>,
         _9 : parse_opt_part_id                      >>
         (AddOrderMsg{ timestamp : _1, 
                       msg_type  : _2, 
-                      order_id  : _3, 
+                      id  : _3, 
                       side      : _4,
                       shares    : _5, 
                       symbol    : _6, 
@@ -272,7 +272,7 @@ named!(parse_order_cancel<&str, OrderCancelMsg>,
         _4 : map_res!(take!(6),  FromStr::from_str) >>
         (OrderCancelMsg{ timestamp : _1, 
                          msg_type  : _2, 
-                         order_id  : _3, 
+                         id  : _3, 
                          shares    : _4,
                     })  
     )
@@ -287,7 +287,7 @@ named!(parse_order_executed<&str, OrderExecutedMsg>,
         _5 : map_res!(take!(12), from_base36)       >>
         (OrderExecutedMsg{ timestamp : _1, 
                          msg_type    : _2, 
-                         order_id    : _3, 
+                         id    : _3, 
                          shares      : _4,
                          exec_id     : _5
                     })  
@@ -335,7 +335,7 @@ named!(parse_trade<&str, TradeMsg>,
         _8 : map_res!(take!(12), from_base36)       >>  
         (TradeMsg{ timestamp : _1, 
                    msg_type  : _2, 
-                   order_id  : _3, 
+                   id  : _3, 
                    side      : _4, 
                    shares    : _5, 
                    symbol    : _6, 

--- a/rust/src/orderbook.rs
+++ b/rust/src/orderbook.rs
@@ -349,5 +349,13 @@ impl LOBService {
         
     }
 
+    pub fn get_msg_channel(&self) -> Result<Sender<Option<Order>>, &'static str >{
+        match self.msg_send.as_ref() {
+            Some(s) => Ok(s.clone()),
+            None => Err("Channel not initialized"),
+        }
+        
+    }
+
 }
 

--- a/rust/src/orderbook.rs
+++ b/rust/src/orderbook.rs
@@ -27,9 +27,9 @@ pub struct PriceBucket {
 }
 
 pub struct Execution {
-    volume: u32, 
-    buy_order_id: u64, 
-    sell_order_id: u64
+    pub volume: u32, 
+    pub buy_order_id: u64, 
+    pub sell_order_id: u64
 }
 
 impl fmt::Debug for PriceBucket {

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -17,6 +17,7 @@ use orderbook::OrderManager;
 use orderbook::AskBook;
 use orderbook::BestPrice;
 use orderbook::LimitOrderBook;
+use orderbook::LOBService;
 
 use std::env;
 use std::fs::File;
@@ -196,6 +197,7 @@ fn test_book() {
 fn test_limit_order_book() {
 
     let mut b = LimitOrderBook::new();
+
     let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
     let o2 = Order{order_id : 2002, price : 10050, volume : 200, side : 1, part_id : String::from("Acme Corp.")};
     let o3 = Order{order_id : 2003, price : 10100, volume : 300, side : 1, part_id : String::from("Acme Corp.")};
@@ -210,7 +212,7 @@ fn test_limit_order_book() {
     b.add_order(o5);
     b.add_order(o6);
 
-    println!("==========> HERE");
+//     println!("==========> HERE");
     assert_eq!(b.best_bid(), 10100 );
     assert_eq!(b.best_ask(), 10200 );
 
@@ -224,21 +226,26 @@ fn test_limit_order_book() {
 
 #[test]
 fn test_lob_threading() {
-
-    let mut b = LimitOrderBook::new();
-    let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
-    println!("----------> testing...", );
-    b.start_workers();
-    b.add_request(o1);
-    //b.wait_till_done();
-
-    thread::sleep(time::Duration::from_secs(5));
+    let mut b = LOBService::new();
+    // b.start_workers();
 }
+// #[test]
+// fn test_lob_threading() {
+
+//     let mut b = LimitOrderBook::new();
+//     let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
+//     println!("----------> testing...", );
+//     b.start_workers();
+//     b.add_request(o1);
+//     //b.wait_till_done();
+
+//     thread::sleep(time::Duration::from_secs(5));
+// }
 
 
 
-#[test]
-fn test_example() {
+// #[test]
+// fn test_example() {
 
 
-}
+// }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -46,7 +46,7 @@ fn test_parse_add_order() {
     let o = res.unwrap();        
     assert_eq!(o.timestamp, 28800168);
     assert_eq!( o.msg_type, 'A');
-    assert_eq!( o.order_id,  204969015920664610);
+    assert_eq!( o.id,  204969015920664610);
     assert_eq!( o.side,     'S');
     assert_eq!( o.shares,   100);
     assert_eq!( o.symbol,   "AAPL  ");
@@ -159,9 +159,9 @@ fn test_factory() {
 fn test_price_bucket() {
 
     let mut pb = PriceBucket::from_price(1200000);
-    let o = Order{order_id : 2001, price : 1200000, volume : 100, side : 1, 
+    let o = Order{id : 2001, price : 1200000, volume : 100, side : 1, 
                   part_id : String::from("Acme Corp.") };
-    let o2 = Order{order_id : 2002, price : 1200000, volume : 220, side : 1, 
+    let o2 = Order{id : 2002, price : 1200000, volume : 220, side : 1, 
                   part_id : String::from("TH Inc.") };     
 
     pb.add_order( o );
@@ -179,10 +179,10 @@ fn test_price_bucket() {
 fn test_book() {
     
     let mut book = AskBook::new();
-    let o = Order{order_id : 2001, price : 1200000, volume : 150, side : -1, 
+    let o = Order{id : 2001, price : 1200000, volume : 150, side : -1, 
                   part_id : String::from("Acme Corp.") };
 
-    let o2 = Order{order_id : 2002, price : 1300000, volume : 220, side : -1, 
+    let o2 = Order{id : 2002, price : 1300000, volume : 220, side : -1, 
                   part_id : String::from("TH Inc.") };     
 
     book.add_order(o.clone());
@@ -199,12 +199,12 @@ fn test_limit_order_book() {
 
     let mut b = LimitOrderBook::new();
 
-    let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
-    let o2 = Order{order_id : 2002, price : 10050, volume : 200, side : 1, part_id : String::from("Acme Corp.")};
-    let o3 = Order{order_id : 2003, price : 10100, volume : 300, side : 1, part_id : String::from("Acme Corp.")};
-    let o4 = Order{order_id : 2004, price : 10200, volume : 400, side : -1, part_id : String::from("Acme Corp.")};
-    let o5 = Order{order_id : 2005, price : 10250, volume : 500, side : -1, part_id : String::from("Acme Corp.")};
-    let o6 = Order{order_id : 2006, price : 10300, volume : 600, side : -1, part_id : String::from("Acme Corp.")};
+    let o1 = Order{id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
+    let o2 = Order{id : 2002, price : 10050, volume : 200, side : 1, part_id : String::from("Acme Corp.")};
+    let o3 = Order{id : 2003, price : 10100, volume : 300, side : 1, part_id : String::from("Acme Corp.")};
+    let o4 = Order{id : 2004, price : 10200, volume : 400, side : -1, part_id : String::from("Acme Corp.")};
+    let o5 = Order{id : 2005, price : 10250, volume : 500, side : -1, part_id : String::from("Acme Corp.")};
+    let o6 = Order{id : 2006, price : 10300, volume : 600, side : -1, part_id : String::from("Acme Corp.")};
 
     b.add_order(o1);
     b.add_order(o2);
@@ -220,8 +220,8 @@ fn test_limit_order_book() {
     assert_eq!(b.ask_iter().next().unwrap().0, &10200 );
     assert_eq!(b.ask_iter().next_back().unwrap().0, &10300 );
 
-    let o7 = Order{order_id : 2007, price : 10225, volume : 300, side : 1, part_id : String::from("Acme Corp.")};
-    b.add_order(o7);
+    let o7 = Order{id : 2007, price : 10225, volume : 300, side : 1, part_id : String::from("Acme Corp.")};
+    let executions = b.add_order(o7);
     assert_eq!(b.ask_volume_at_price_level(10200), 100);
 }
 
@@ -234,7 +234,7 @@ fn test_lob_threading() {
 
     match send_channel {
         Ok(s) => {
-            let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
+            let o1 = Order{id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
             s.send(Some(o1));
         },
         Err(s) => {

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -24,6 +24,7 @@ use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::{thread, time};
+use std::thread::sleep;
 
 #[test]
 fn test_parse_auction_summary() {
@@ -227,25 +228,7 @@ fn test_limit_order_book() {
 #[test]
 fn test_lob_threading() {
     let mut b = LOBService::new();
-    // b.start_workers();
+    b.start_service();
+    b.stop_service();
 }
-// #[test]
-// fn test_lob_threading() {
 
-//     let mut b = LimitOrderBook::new();
-//     let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
-//     println!("----------> testing...", );
-//     b.start_workers();
-//     b.add_request(o1);
-//     //b.wait_till_done();
-
-//     thread::sleep(time::Duration::from_secs(5));
-// }
-
-
-
-// #[test]
-// fn test_example() {
-
-
-// }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -229,6 +229,19 @@ fn test_limit_order_book() {
 fn test_lob_threading() {
     let mut b = LOBService::new();
     b.start_service();
+    
+    let send_channel = b.get_msg_channel();
+
+    match send_channel {
+        Ok(s) => {
+            let o1 = Order{order_id : 2001, price : 10000, volume : 100, side : 1, part_id : String::from("Acme Corp.")};
+            s.send(Some(o1));
+        },
+        Err(s) => {
+            assert!(false, "Channel not initialized!")            
+        }
+
+    }
     b.stop_service();
 }
 

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -221,7 +221,12 @@ fn test_limit_order_book() {
     assert_eq!(b.ask_iter().next_back().unwrap().0, &10300 );
 
     let o7 = Order{id : 2007, price : 10225, volume : 300, side : 1, part_id : String::from("Acme Corp.")};
+
     let executions = b.add_order(o7);
+    assert_eq!(executions.len(), 1);
+    let exec = &executions[0]; 
+    assert_eq!(exec.volume, 300);
+
     assert_eq!(b.ask_volume_at_price_level(10200), 100);
 }
 


### PR DESCRIPTION
1. Introduce Rust LOBService wrapping the LOB in a separate thread.
2. Use channels for shuffling orders between LOB thread and client
3. Add support for executions when calling add_order()